### PR TITLE
Refactor: JWT 토큰 만료시간 연장

### DIFF
--- a/kidsping/src/main/java/com/kidsworld/kidsping/global/jwt/JwtUtil.java
+++ b/kidsping/src/main/java/com/kidsworld/kidsping/global/jwt/JwtUtil.java
@@ -30,7 +30,8 @@ public class JwtUtil {
                 .setClaims(claims)
                 .setSubject(subject)
                 .setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 10))
+//                .setExpiration(new Date(System.currentTimeMillis() + 1000L * 60 * 60)) // 1시간
+                .setExpiration(new Date(System.currentTimeMillis() + 1000L * 60 * 60 * 24 * 30)) // 임시 30일
                 .signWith(key,SignatureAlgorithm.HS256)
                 .compact();
     }


### PR DESCRIPTION
### 작업 내용
- JWT 토큰 만료 시간 연장
  - 기존: 10시간 -> 변경: 30일
  - 테스트를 위해 30일로 연장

### 작업 결과
- 정상 컴파일 확인
