### PR TITLE
Feat: Redis로 이벤트 목록 캐싱

### DIFF
--- a/kidsping/src/main/java/com/kidsworld/kidsping/domain/event/controller/EventController.java
+++ b/kidsping/src/main/java/com/kidsworld/kidsping/domain/event/controller/EventController.java
@@ -11,6 +11,8 @@ import com.kidsworld.kidsping.global.common.dto.ApiResponse;
 import com.kidsworld.kidsping.global.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -32,6 +34,7 @@ public class EventController {
     private final EventService eventService;
 
     @PostMapping
+    @CacheEvict(value = "eventPagesCache", allEntries = true)
     public ResponseEntity<ApiResponse<CreateEventResponse>> createEvent(@RequestBody CreateEventRequest request) {
         CreateEventResponse response = eventService.createEvent(request);
         return ApiResponse.ok(ExceptionCode.OK.getCode(), response, ExceptionCode.OK.getMessage());
@@ -44,12 +47,14 @@ public class EventController {
     }
 
     @GetMapping
+    @Cacheable(value = "eventPagesCache", key = "#pageable.pageNumber")
     public ResponseEntity<ApiResponse<Page<GetEventResponse>>> getAllEvents(Pageable pageable) {
         Page<GetEventResponse> response = eventService.getAllEvents(pageable);
         return ApiResponse.ok(ExceptionCode.OK.getCode(), response, ExceptionCode.OK.getMessage());
     }
 
     @PutMapping("/{id}")
+    @CacheEvict(value = "eventPagesCache", allEntries = true)
     public ResponseEntity<ApiResponse<UpdateEventResponse>> updateEvent(
             @PathVariable Long id,
             @RequestBody UpdateEventRequest request) {
@@ -59,6 +64,7 @@ public class EventController {
     }
 
     @DeleteMapping("/{id}")
+    @CacheEvict(value = "eventPagesCache", allEntries = true)
     public ResponseEntity<ApiResponse<DeleteEventResponse>> deleteEvent(@PathVariable Long id) {
         DeleteEventResponse response = eventService.deleteEvent(id);
         return ApiResponse.ok(ExceptionCode.OK.getCode(), response, ExceptionCode.OK.getMessage());

--- a/kidsping/src/main/java/com/kidsworld/kidsping/global/config/RedisCacheConfig.java
+++ b/kidsping/src/main/java/com/kidsworld/kidsping/global/config/RedisCacheConfig.java
@@ -1,0 +1,36 @@
+package com.kidsworld.kidsping.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class RedisCacheConfig {
+
+    @Value("${spring.cache.redis.time-to-live}")
+    private Duration cacheTtl;
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(cacheTtl)
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())) // key: string
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer())); // value: json
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+                .cacheDefaults(cacheConfig)
+                .build();
+    }
+
+}


### PR DESCRIPTION
### 작업 내용
- Redis로 이벤트 목록 캐싱

### 작업 결과
- 정상 컴파일 확인
- 테스트 필요

### Note
- key로 특정 페이지 캐시 무효화가 아닌, 모든 캐시를 무효화한 이유 (allEntries=true) : **데이터 일관성 문제 발생**
  - allEntries=true 로 하면 모든 페이지의 캐시가 삭제되고, getAllEvents가 호출될 때 각 페이지의 데이터를 최신 상태로 캐싱할 수 있게 된다.
  - key로 특정 페이지 캐시 무효화하는 건 단일 페이지 갱신이 자주 일어나는 경우 유리하다.
- 이벤트 목록의 경우, 쓰기 작업보다는 읽기 작업이 많으므로 캐시 만료 시간 30분으로 설정
- @acs0209 embedded redis로 테스트해보려다가 실패해서 테스트 못하고 코드만 올립니다 🥲