### PR TITLE
Refactor: 이벤트 목록 조회 쿼리 파라미터 수정

### DIFF
--- a/kidsping/src/main/java/com/kidsworld/kidsping/domain/event/controller/EventController.java
+++ b/kidsping/src/main/java/com/kidsworld/kidsping/domain/event/controller/EventController.java
@@ -40,7 +40,7 @@ public class EventController {
     }
 
     @GetMapping
-    @Cacheable(value = "eventPagesCache", key = "#pageable.pageNumber")
+    @Cacheable(value = "eventPagesCache", key = "#page + '-' + #size")
     public ResponseEntity<ApiResponse<Page<GetEventResponse>>> getAllEvents(
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "10") int size) {

--- a/kidsping/src/main/java/com/kidsworld/kidsping/domain/event/controller/EventController.java
+++ b/kidsping/src/main/java/com/kidsworld/kidsping/domain/event/controller/EventController.java
@@ -14,16 +14,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -48,8 +41,11 @@ public class EventController {
 
     @GetMapping
     @Cacheable(value = "eventPagesCache", key = "#pageable.pageNumber")
-    public ResponseEntity<ApiResponse<Page<GetEventResponse>>> getAllEvents(Pageable pageable) {
-        Page<GetEventResponse> response = eventService.getAllEvents(pageable);
+    public ResponseEntity<ApiResponse<Page<GetEventResponse>>> getAllEvents(
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size) {
+        PageRequest pageRequest = PageRequest.of(page, size);
+        Page<GetEventResponse> response = eventService.getAllEvents(pageRequest);
         return ApiResponse.ok(ExceptionCode.OK.getCode(), response, ExceptionCode.OK.getMessage());
     }
 

--- a/kidsping/src/test/java/com/kidsworld/kidsping/domain/event/controller/EventControllerTest.java
+++ b/kidsping/src/test/java/com/kidsworld/kidsping/domain/event/controller/EventControllerTest.java
@@ -18,16 +18,16 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -100,12 +100,16 @@ class EventControllerTest {
     @DisplayName("진행중인 이벤트 조회 테스트")
     void getAllEvents_진행중인이벤트조회() {
         // Given
-        Pageable pageable = Pageable.unpaged();
-        Page<GetEventResponse> expectedResponse = mock(Page.class);
-        when(eventService.getAllEvents(pageable)).thenReturn(expectedResponse);
+        int page = 0;
+        int size = 10;
+        PageRequest pageRequest = PageRequest.of(page, size);
+        GetEventResponse eventResponse = GetEventResponse.of(mockEvent);
+        Page<GetEventResponse> expectedResponse = new PageImpl<>(Collections.singletonList(eventResponse), pageRequest, 1);
+
+        when(eventService.getAllEvents(pageRequest)).thenReturn(expectedResponse);
 
         // When
-        ResponseEntity<ApiResponse<Page<GetEventResponse>>> responseEntity = eventController.getAllEvents(pageable);
+        ResponseEntity<ApiResponse<Page<GetEventResponse>>> responseEntity = eventController.getAllEvents(page, size);
 
         // Then
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);


### PR DESCRIPTION
### 작업 내용
- 이벤트 목록 조회 쿼리 파라미터 수정 (Pageble -> page, size)
- 이벤트 목록 조회 테스트 코드 수정
- cache key 변경 (pageable 사용 -> page-size 형태)

### 작업 결과
- 정상 컴파일 확인
- 정상 동작 확인