### PR TITLE
Refactor: 이벤트 목록 캐싱 구현 & 테스트 코드 작성

### DIFF
--- a/kidsping/src/main/java/com/kidsworld/kidsping/domain/event/controller/EventController.java
+++ b/kidsping/src/main/java/com/kidsworld/kidsping/domain/event/controller/EventController.java
@@ -7,14 +7,12 @@ import com.kidsworld.kidsping.domain.event.dto.response.DeleteEventResponse;
 import com.kidsworld.kidsping.domain.event.dto.response.GetEventResponse;
 import com.kidsworld.kidsping.domain.event.dto.response.UpdateEventResponse;
 import com.kidsworld.kidsping.domain.event.service.EventService;
+import com.kidsworld.kidsping.global.cache.CachedPage;
 import com.kidsworld.kidsping.global.common.dto.ApiResponse;
 import com.kidsworld.kidsping.global.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -27,7 +25,6 @@ public class EventController {
     private final EventService eventService;
 
     @PostMapping
-    @CacheEvict(value = "eventPagesCache", allEntries = true)
     public ResponseEntity<ApiResponse<CreateEventResponse>> createEvent(@RequestBody CreateEventRequest request) {
         CreateEventResponse response = eventService.createEvent(request);
         return ApiResponse.ok(ExceptionCode.OK.getCode(), response, ExceptionCode.OK.getMessage());
@@ -40,17 +37,16 @@ public class EventController {
     }
 
     @GetMapping
-    @Cacheable(value = "eventPagesCache", key = "'event:list:page:' + #page + ':size:' + #size")
     public ResponseEntity<ApiResponse<Page<GetEventResponse>>> getAllEvents(
-            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "page", defaultValue = "1") int page,
             @RequestParam(name = "size", defaultValue = "10") int size) {
-        PageRequest pageRequest = PageRequest.of(page, size);
-        Page<GetEventResponse> response = eventService.getAllEvents(pageRequest);
+
+        CachedPage<GetEventResponse> response = eventService.getAllEvents(page, size);
+
         return ApiResponse.ok(ExceptionCode.OK.getCode(), response, ExceptionCode.OK.getMessage());
     }
 
     @PutMapping("/{id}")
-    @CacheEvict(value = "eventPagesCache", allEntries = true)
     public ResponseEntity<ApiResponse<UpdateEventResponse>> updateEvent(
             @PathVariable Long id,
             @RequestBody UpdateEventRequest request) {
@@ -60,7 +56,6 @@ public class EventController {
     }
 
     @DeleteMapping("/{id}")
-    @CacheEvict(value = "eventPagesCache", allEntries = true)
     public ResponseEntity<ApiResponse<DeleteEventResponse>> deleteEvent(@PathVariable Long id) {
         DeleteEventResponse response = eventService.deleteEvent(id);
         return ApiResponse.ok(ExceptionCode.OK.getCode(), response, ExceptionCode.OK.getMessage());

--- a/kidsping/src/main/java/com/kidsworld/kidsping/domain/event/dto/response/GetEventResponse.java
+++ b/kidsping/src/main/java/com/kidsworld/kidsping/domain/event/dto/response/GetEventResponse.java
@@ -1,13 +1,14 @@
 package com.kidsworld.kidsping.domain.event.dto.response;
 
 import com.kidsworld.kidsping.domain.event.entity.Event;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Builder
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class GetEventResponse {
 
     private Long id;

--- a/kidsping/src/main/java/com/kidsworld/kidsping/domain/event/service/EventService.java
+++ b/kidsping/src/main/java/com/kidsworld/kidsping/domain/event/service/EventService.java
@@ -1,12 +1,9 @@
 package com.kidsworld.kidsping.domain.event.service;
 
-import com.kidsworld.kidsping.domain.event.dto.request.ApplyCouponRequest;
 import com.kidsworld.kidsping.domain.event.dto.request.CreateEventRequest;
-import com.kidsworld.kidsping.domain.event.dto.request.CheckWinnerRequest;
 import com.kidsworld.kidsping.domain.event.dto.request.UpdateEventRequest;
 import com.kidsworld.kidsping.domain.event.dto.response.*;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import com.kidsworld.kidsping.global.cache.CachedPage;
 
 
 public interface EventService {
@@ -15,7 +12,7 @@ public interface EventService {
 
     GetEventResponse getEvent(Long id);
 
-    Page<GetEventResponse> getAllEvents(Pageable pageable);
+    CachedPage<GetEventResponse> getAllEvents(int page, int size);
 
     UpdateEventResponse updateEvent(Long id, UpdateEventRequest updateEventRequest);
 

--- a/kidsping/src/main/java/com/kidsworld/kidsping/global/cache/CachedPage.java
+++ b/kidsping/src/main/java/com/kidsworld/kidsping/global/cache/CachedPage.java
@@ -1,0 +1,28 @@
+package com.kidsworld.kidsping.global.cache;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
+@JsonIgnoreProperties(ignoreUnknown = true, value = {"pageable"})
+public class CachedPage<T> extends PageImpl<T> {
+
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public CachedPage(@JsonProperty("content") List<T> content,
+                      @JsonProperty("number") int page,
+                      @JsonProperty("size") int size,
+                      @JsonProperty("totalElements") long total) {
+        super(content, PageRequest.of(page, size), total);
+    }
+
+    public CachedPage(Page<T> page) {
+        super(page.getContent(), page.getPageable(), page.getTotalElements());
+    }
+}

--- a/kidsping/src/main/java/com/kidsworld/kidsping/global/config/RedisCacheConfig.java
+++ b/kidsping/src/main/java/com/kidsworld/kidsping/global/config/RedisCacheConfig.java
@@ -1,5 +1,9 @@
 package com.kidsworld.kidsping.global.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
@@ -23,10 +27,20 @@ public class RedisCacheConfig {
 
     @Bean
     public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+
+        PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator
+                .builder()
+                .allowIfSubType(Object.class)
+                .build();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.activateDefaultTyping(typeValidator, ObjectMapper.DefaultTyping.NON_FINAL);
+
         RedisCacheConfiguration cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
                 .entryTtl(cacheTtl)
                 .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())) // key: string
-                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer())); // value: json
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer(objectMapper))); // value: json
 
         return RedisCacheManager.builder(redisConnectionFactory)
                 .cacheDefaults(cacheConfig)

--- a/kidsping/src/test/java/com/kidsworld/kidsping/domain/event/controller/EventControllerTest.java
+++ b/kidsping/src/test/java/com/kidsworld/kidsping/domain/event/controller/EventControllerTest.java
@@ -8,6 +8,7 @@ import com.kidsworld.kidsping.domain.event.dto.response.GetEventResponse;
 import com.kidsworld.kidsping.domain.event.dto.response.UpdateEventResponse;
 import com.kidsworld.kidsping.domain.event.entity.Event;
 import com.kidsworld.kidsping.domain.event.service.EventService;
+import com.kidsworld.kidsping.global.cache.CachedPage;
 import com.kidsworld.kidsping.global.common.dto.ApiResponse;
 import com.kidsworld.kidsping.global.exception.ExceptionCode;
 import org.junit.jupiter.api.BeforeEach;
@@ -100,13 +101,18 @@ class EventControllerTest {
     @DisplayName("진행중인 이벤트 조회 테스트")
     void getAllEvents_진행중인이벤트조회() {
         // Given
-        int page = 0;
+        int page = 1;
         int size = 10;
-        PageRequest pageRequest = PageRequest.of(page, size);
         GetEventResponse eventResponse = GetEventResponse.of(mockEvent);
-        Page<GetEventResponse> expectedResponse = new PageImpl<>(Collections.singletonList(eventResponse), pageRequest, 1);
 
-        when(eventService.getAllEvents(pageRequest)).thenReturn(expectedResponse);
+        CachedPage<GetEventResponse> expectedResponse = new CachedPage<>(
+                Collections.singletonList(eventResponse), // content
+                0, // number (페이지 번호)
+                size, // size
+                1 // totalElements (총 개수)
+        );
+
+        when(eventService.getAllEvents(page, size)).thenReturn(expectedResponse);
 
         // When
         ResponseEntity<ApiResponse<Page<GetEventResponse>>> responseEntity = eventController.getAllEvents(page, size);

--- a/kidsping/src/test/java/com/kidsworld/kidsping/domain/event/service/EventCacheTest.java
+++ b/kidsping/src/test/java/com/kidsworld/kidsping/domain/event/service/EventCacheTest.java
@@ -2,11 +2,11 @@ package com.kidsworld.kidsping.domain.event.service;
 
 import com.kidsworld.kidsping.domain.event.dto.request.CreateEventRequest;
 import com.kidsworld.kidsping.domain.event.dto.request.UpdateEventRequest;
+import com.kidsworld.kidsping.domain.event.entity.Event;
+import com.kidsworld.kidsping.domain.event.repository.EventRepository;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,18 +20,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 class EventCacheTest {
 
     @Autowired
-    private EventService eventService;
+    private EventServiceImpl eventService;
+
+    @Autowired
+    private EventRepository eventRepository;
 
     @Autowired
     private RedisTemplate<String, Object> redisTemplate;
 
-    private final int page = 0;
+    private final int page = 1;
     private final int size = 10;
+    private long eventId;
 
     @BeforeEach
     public void setUp() {
-        // 이벤트 생성
-        CreateEventRequest eventRequest = CreateEventRequest.builder()
+        Event event = Event.builder()
                 .eventName("Test Event")
                 .eventContent("Test Event Content")
                 .maxParticipants(100L)
@@ -40,16 +43,12 @@ class EventCacheTest {
                 .endTime(LocalDateTime.now().plusDays(2))
                 .build();
 
-        eventService.createEvent(eventRequest);
+        eventId = eventRepository.save(event).getId();
 
-        // 캐시를 위해 getAllEvents 호출
-        int page = 0;
-        int size = 10;
-        Pageable pageable = PageRequest.of(page, size);
-        eventService.getAllEvents(pageable);
+        // 캐시 저장
+        eventService.getAllEvents(page, size);
 
-        // 캐시에 데이터가 저장되었는지 확인
-        String cacheKey = "event:list:page:" + page + ":size:" + size;
+        String cacheKey = "eventPagesCache::events:page:" + page + ":size:" + size;
         Object cachedEvents = redisTemplate.opsForValue().get(cacheKey);
         assertThat(cachedEvents).isNotNull();
     }
@@ -57,15 +56,11 @@ class EventCacheTest {
     @Test
     @DisplayName("진행중인 이벤트 캐싱 테스트")
     void getAllEvents_캐시테스트() throws InterruptedException {
-        // Given
-        int page = 1;
-        Pageable pageable = PageRequest.of(page, size);
-
         // When: 처음 호출하여 캐시 저장
-        eventService.getAllEvents(pageable);
+        eventService.getAllEvents(page, size);
 
         // 캐시에 데이터가 저장되었는지 확인
-        String cacheKey = "event:list:page:" + page + ":size:" + size;
+        String cacheKey = "eventPagesCache::events:page:" + page + ":size:" + size;
         Object cachedEvents = redisTemplate.opsForValue().get(cacheKey);
         assertThat(cachedEvents).isNotNull();
 
@@ -90,7 +85,7 @@ class EventCacheTest {
                 .endTime(LocalDateTime.now().plusDays(2))
                 .build();
 
-        String cacheKey = "event:list:page:" + page + ":size:" + size;
+        String cacheKey = "eventPagesCache::events:page:" + page + ":size:" + size;
 
         // When: 이벤트 생성
         eventService.createEvent(request);
@@ -101,10 +96,10 @@ class EventCacheTest {
     }
 
     @Test
-    @DisplayName("이벤트 업데이트 시 캐시 삭제 테스트")
+    @DisplayName("이벤트 수정 시 캐시 삭제 테스트")
     void updateEvent_캐시삭제테스트() {
         // Given
-        UpdateEventRequest updateRequest = UpdateEventRequest.builder()
+        UpdateEventRequest request = UpdateEventRequest.builder()
                 .eventName("Updated Event")
                 .eventContent("Updated Content")
                 .maxParticipants(200L)
@@ -116,7 +111,7 @@ class EventCacheTest {
         String cacheKey = "event:list:page:" + page + ":size:" + size;
 
         // When: 이벤트 업데이트
-        eventService.updateEvent(1L, updateRequest);
+        eventService.updateEvent(eventId, request);
 
         // Then: 캐시 삭제 확인
         Object cachedEvents = redisTemplate.opsForValue().get(cacheKey);
@@ -130,7 +125,7 @@ class EventCacheTest {
         String cacheKey = "event:list:page:" + page + ":size:" + size;
 
         // When: 이벤트 삭제
-        eventService.deleteEvent(1L);
+        eventService.deleteEvent(eventId);
 
         // Then: 캐시 삭제 확인
         Object cachedEvents = redisTemplate.opsForValue().get(cacheKey);


### PR DESCRIPTION
### 작업 내용
- 이벤트 목록 조회 시, 페이지별 캐싱
- 이벤트 변경 시, 캐시 무효화
- 캐싱 시 Page 객체 받는 CachePage 커스텀 클래스 생성
- 캐싱 시 직렬화/역직렬화 위한 CacheManager Serializer 수정
- 테스트 코드 작성 (이벤트 컨트롤러, 이벤트 목록 캐싱)

### 작업 결과
- 정상 컴파일 확인
- 정상 동작 확인
<img width="364" alt="image" src="https://github.com/user-attachments/assets/b3701913-49c9-4f5c-a994-bd142c6c740c">
<img width="364" alt="image" src="https://github.com/user-attachments/assets/eef48f26-06c2-4423-b32d-2a80da9053c9">

