### PR TITLE
Refactor: API마다 캐시 TTL 다르게 설정하도록 config 수정

### DIFF
--- a/kidsping/src/main/java/com/kidsworld/kidsping/global/batch/scheduler/CouponScheduler.java
+++ b/kidsping/src/main/java/com/kidsworld/kidsping/global/batch/scheduler/CouponScheduler.java
@@ -29,8 +29,8 @@ public class CouponScheduler {
     private final UserRepository userRepository;
     private final EventRepository eventRepository;
 
-    @Scheduled(cron = "0 0 4 * * *")
-//  @Scheduled(cron = "*/10 * * * * *")  // 매 10초마다 실행 for Test
+//    @Scheduled(cron = "0 0 4 * * *")
+  @Scheduled(cron = "*/10 * * * * *")  // 매 10초마다 실행 for Test
     @Transactional
     public void saveRedisDataToDatabase() {
         Set<String> keys = redisTemplate.keys("EVENT:*USER:*");


### PR DESCRIPTION
### 작업 내용
- API마다 캐시 TTL 다르게 설정하도록 config 수정

### 작업 결과
- 정상 컴파일 확인
- 정상 동작 확인
